### PR TITLE
feat: Refactor compliance address components and columns

### DIFF
--- a/app/compliance/[address]/page.tsx
+++ b/app/compliance/[address]/page.tsx
@@ -1,19 +1,12 @@
-import { getProfileByAddressAction } from "@/app/actions/kyc/getProfileByAddressAction";
 import { Wrapper } from "@/components/compliance/address/wrapper";
 
 export default async function Address({ params }: { params: { address: string } }) {
-
-  const user = await getProfileByAddressAction(params.address)
-  console.log(user)
-
-
-
   
 
 
   return (
     <div className="flex w-screen h-screen">
-      <Wrapper address={params.address} user={user!}/>
+      <Wrapper address={params.address} />
     </div>
   );
 }

--- a/components/compliance/address/authorized.tsx
+++ b/components/compliance/address/authorized.tsx
@@ -8,7 +8,7 @@ interface AuthorizedProps {
 }
 
 export function Authorized({ address }: AuthorizedProps) {
-    const { profile, loading } = useGetProfile(address as `0x${string}`)
+    const { profile } = useGetProfile(address as `0x${string}`)
     const router = useRouter()
     
     console.log(profile)

--- a/components/compliance/address/authorized.tsx
+++ b/components/compliance/address/authorized.tsx
@@ -1,10 +1,35 @@
+import { Menu } from "@/components/topnav/menu"
+import { useGetProfile } from "@/hooks/kyc/useGetProfile"
+import { ArrowLeft, Check } from "lucide-react"
+import { useRouter } from "next/navigation"
+
 interface AuthorizedProps {
     address: string
-    user: string
 }
 
-export function Authorized({ address, user }: AuthorizedProps) {
-    console.log(address)
-    console.log(user)
-    return <div>Authorized</div>
+export function Authorized({ address }: AuthorizedProps) {
+    const { profile, loading } = useGetProfile(address as `0x${string}`)
+    const router = useRouter()
+    
+    console.log(profile)
+    return (
+        <main className="flex h-full w-full">
+            <div className="flex flex-col h-full p-4 md:p-6 lg:p-8 w-full gap-6">
+                <Menu/>
+
+                <div className="flex flex-col w-full justify-center items-center">
+                    <div className="flex w-full max-w-[66rem] items-center">
+                        <ArrowLeft className="h-8 w-8" onClick={() =>  router.push("/assign")}/>
+                    </div>
+                </div>
+                <div className="flex flex-col w-full justify-center items-center">
+                    <div className="flex w-full max-w-[66rem] justify-end">
+                        <Check/>
+                        
+                    </div>
+                </div>  
+                
+            </div>
+        </main>
+    )
 }

--- a/components/compliance/address/wrapper.tsx
+++ b/components/compliance/address/wrapper.tsx
@@ -8,7 +8,6 @@ import { useRouter } from "next/navigation";
 import { Authorized } from "./authorized";
 import { Unauthorized } from "./unauthorized";
 import { useEffect } from "react";
-import { Profile } from "@/hooks/kyc/useGetProfile";
 
 interface WrapperProps {    
     address: string

--- a/components/compliance/address/wrapper.tsx
+++ b/components/compliance/address/wrapper.tsx
@@ -3,21 +3,22 @@
 
 "use client"
 
-//import { useRouter } from "next/navigation";
+import { usePrivy } from "@privy-io/react-auth";
+import { useRouter } from "next/navigation";
 import { Authorized } from "./authorized";
 import { Unauthorized } from "./unauthorized";
-import { useGetProfile } from "@/hooks/kyc/useGetProfile";
+import { useEffect } from "react";
+import { Profile } from "@/hooks/kyc/useGetProfile";
 
 interface WrapperProps {    
     address: string
-    user: string
 }
 
-export function Wrapper({ address, user }: WrapperProps) {
-    //const { user, ready, authenticated } = usePrivy()
-    //const router = useRouter()
-    const { profile, loading } = useGetProfile(address as `0x${string}`)
-    /*
+export function Wrapper({ address }: WrapperProps) {
+    const { user, ready, authenticated } = usePrivy()
+    const router = useRouter()
+    
+    
 
     useEffect(() => {
         if (ready && authenticated && !user?.customMetadata) {
@@ -25,12 +26,12 @@ export function Wrapper({ address, user }: WrapperProps) {
         }
 
     }, [ready, authenticated, router, user?.customMetadata])
-    */
+    
     return (
         <>
         {
 
-            !loading 
+            !ready 
             ?(
                 <>
                     <main className="flex min-h-screen flex-col items-center justify-between p-24">
@@ -42,8 +43,8 @@ export function Wrapper({ address, user }: WrapperProps) {
                 <>
                     <main className="flex w-full h-full">
                     {
-                        profile
-                        ? <Authorized address={address} user={user}/>
+                        authenticated
+                        ? <Authorized address={address} />
                         : <Unauthorized/>
                     }
                     </main>

--- a/components/compliance/columns.tsx
+++ b/components/compliance/columns.tsx
@@ -41,11 +41,11 @@ export const Columns: ColumnDef<Profile>[] = [
         header: "Lastname",
     },
     {
-        accessorKey: "compliant",
-        header: "Compliant",
+        accessorKey: "id",
+        header: "id",
         cell: ({row}) => {
-            const compliant = (row.getValue("compliant"))
-            return <div>{compliant ? "Compliant" : "Non-Compliant"}</div>
+            const id = (row.getValue("id"))
+            return <div>{(id as string).toString().charAt(0).toUpperCase() + (id as string).slice(1)}</div>
         },
     },
     {


### PR DESCRIPTION
Updated Authorized and Wrapper components to use authentication state from Privy and removed unused user prop. Refactored columns to display 'id' instead of 'compliant' status. Improved UI structure and navigation in Authorized component.