### PR TITLE
feat: Refactor compliance approval and add setCompliance action

### DIFF
--- a/app/actions/setCompliance.ts
+++ b/app/actions/setCompliance.ts
@@ -1,0 +1,15 @@
+"use server"
+
+import { fleetOrderBookAbi } from "@/utils/abis/fleetOrderBook"
+import { walletClient } from "@/utils/client"
+import { fleetOrderBook } from "@/utils/constants/addresses"
+
+export const setCompliance = async (address: string) => {
+    const tx = await walletClient.writeContract({
+        address: fleetOrderBook,
+        abi: fleetOrderBookAbi,
+        functionName: "setCompliance",
+        args: [[address as `0x${string}`]],
+    })
+    return tx
+}

--- a/components/compliance/address/authorized.tsx
+++ b/components/compliance/address/authorized.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { useGetProfile } from "@/hooks/kyc/useGetProfile"
 import { fleetOrderBookAbi } from "@/utils/abis/fleetOrderBook"
-import { publicClient, walletClient } from "@/utils/client"
+import { publicClient } from "@/utils/client"
 import { fleetOrderBook } from "@/utils/constants/addresses"
 import { trimRef } from "@/utils/trim"
 import { useQueryClient } from "@tanstack/react-query"
@@ -57,6 +57,7 @@ export function Authorized({ address }: AuthorizedProps) {
                 if (updatedProfile && profile) {
                     // send email to user
                     const email = await sendProfileVerifiedMail(profile?.email, profile?.firstname)
+                    console.log(email)
                     setLoading(false)
                 }
             }
@@ -66,7 +67,7 @@ export function Authorized({ address }: AuthorizedProps) {
         }           
     }
 
-
+/*
     async function handleRejectedCompliance() {
         setLoading(true)
         try {
@@ -76,7 +77,7 @@ export function Authorized({ address }: AuthorizedProps) {
             setLoading(false)
         }           
     }
-
+*/
     console.log(profile)
     return (
         <main className="flex h-full w-full">

--- a/components/compliance/address/authorized.tsx
+++ b/components/compliance/address/authorized.tsx
@@ -1,5 +1,6 @@
 import { updateProfileComplianceAction } from "@/app/actions/kyc/updateProfileComplianceAction"
 import { sendProfileVerifiedMail } from "@/app/actions/mail/sendProfileVerifiedMail"
+import { setCompliance } from "@/app/actions/setCompliance"
 import { Menu } from "@/components/topnav/menu"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -42,16 +43,11 @@ export function Authorized({ address }: AuthorizedProps) {
     }, [blockNumber, compliantQueryClient, compliantQueryKey]) 
 
 
-    async function handleCompliance() {
+    async function handleApprovedCompliance() {
         setLoading(true)
         try {
             // set compliance to true
-            const tx = await walletClient.writeContract({
-                address: fleetOrderBook,
-                abi: fleetOrderBookAbi,
-                functionName: "setCompliance",
-                args: [[address as `0x${string}`]],
-            })
+            const tx = await setCompliance(address as `0x${string}`)
             const receipt = await publicClient.waitForTransactionReceipt({ hash: tx })
             console.log(receipt)
             if (receipt.status === "success") {
@@ -61,10 +57,20 @@ export function Authorized({ address }: AuthorizedProps) {
                 if (updatedProfile && profile) {
                     // send email to user
                     const email = await sendProfileVerifiedMail(profile?.email, profile?.firstname)
-                    console.log(email)
+                    setLoading(false)
                 }
             }
+        } catch (error) {
+            console.log(error)
             setLoading(false)
+        }           
+    }
+
+
+    async function handleRejectedCompliance() {
+        setLoading(true)
+        try {
+            // set compliance to false
         } catch (error) {
             console.log(error)
             setLoading(false)
@@ -233,7 +239,7 @@ export function Authorized({ address }: AuthorizedProps) {
                 
                 <div className="flex flex-col w-full justify-center items-center">
                     <div className="flex w-full max-w-[66rem] justify-end">
-                        <Button variant="outline" onClick={handleCompliance} disabled={loading || compliant}>
+                        <Button variant="outline" onClick={handleApprovedCompliance} disabled={loading || compliant}>
                             {
                                 loading
                                 ? <Loader2 className="h-8 w-8 animate-spin" />

--- a/components/compliance/authorized.tsx
+++ b/components/compliance/authorized.tsx
@@ -15,7 +15,7 @@ export function Authorized() {
 
     useEffect(() => {
         if (profiles) {
-            const filtered = profiles.filter(profile => profile.compliant === false)
+            const filtered = profiles.filter(profile => profile.compliant === false && profile.files?.length > 0)
             setProfilesPendingCompliance(filtered)
         }
     }, [profiles])

--- a/utils/client.ts
+++ b/utils/client.ts
@@ -1,3 +1,5 @@
+"use server"
+
 import { Chain, createPublicClient, createWalletClient, http } from 'viem'
 import { celo } from 'viem/chains'
 import { privateKeyToAccount } from 'viem/accounts'


### PR DESCRIPTION
Extracted the compliance contract call into a new server action setCompliance for better code reuse and separation of concerns. Updated the authorized address component to use this new action and improved error handling. Also refined the compliance filtering logic to only include profiles with uploaded files.